### PR TITLE
ci: 添加统一的可复用工作流 actions

### DIFF
--- a/.github/workflows/issue-mark-duplicate.yml
+++ b/.github/workflows/issue-mark-duplicate.yml
@@ -1,0 +1,19 @@
+# force copy from tencent/tdesign
+# 当在 issue 的 comment 回复类似 `Duplicate of #111` 这样的话，issue 将被自动打上 重复提交标签 并且 cloese
+name: Issue Mark Duplicate
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  mark-duplicate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: mark-duplicate
+        uses: actions-cool/issues-helper@v2
+        with:
+          actions: "mark-duplicate"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          duplicate-labels: "duplicate"
+          close-issue: true

--- a/.github/workflows/issue-reply.yml
+++ b/.github/workflows/issue-reply.yml
@@ -1,0 +1,21 @@
+# force copy from tencent/tdesign
+# 当被打上 Need Reproduce 标签时候，自动提示需要重现实例
+
+name: ISSUE_REPLY
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  issue-reply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Need Reproduce
+        if: github.event.label.name == 'Need Reproduce'
+        uses: actions-cool/issues-helper@v2
+        with:
+          actions: 'create-comment'
+          issue-number: ${{ github.event.issue.number }}
+          body: |       
+            你好 @${{ github.event.issue.user.login }}, 我们需要你提供一个在线的重现实例以便于我们帮你排查问题。你可以通过点击 [此处](https://codesandbox.io/) 创建一个 codesandbox 或者提供一个最小化的 GitHub 仓库。请确保选择准确的版本。

--- a/.github/workflows/preview-demo.yml
+++ b/.github/workflows/preview-demo.yml
@@ -1,0 +1,21 @@
+# 文件名建议统一为 preview-publish
+# 应用 preview.yml 的 demo
+
+name: PREVIEW_PUBLISH
+
+on:
+  workflow_run:
+    workflows: ["MAIN_PULL_REQUEST"]
+    types:
+      - completed
+
+jobs:
+  call-preview:
+    uses: Tencent/tdesign/.github/workflows/preview.yml@main
+    with: 
+      project_name: 'tdesign-main'
+      workflow_run_event: github.event.workflow_run.event
+      workflow_run_conclusion: github.event.workflow_run.conclusion
+      workflow_run_workflow_id: github.event.workflow_run.workflow_id
+    # secrets:
+    #   TDESIGN_SURGE_TOKEN: ${{ secrets.TDESIGN_SURGE_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,89 @@
+name: PREVIEW
+
+on:
+  workflow_call:
+    inputs:
+      workflow_run_event:
+        required: true
+        type: string
+        # default: 'pull_request'
+      workflow_run_conclusion:
+        required: true
+        type: string
+        # default: 'true'
+    # secrets:
+    #   TDESIGN_SURGE_TOKEN:
+    #     required: true
+
+jobs:
+  preview-success:
+    runs-on: ubuntu-latest
+    if: >
+      workflow_run_event == 'pull_request' &&
+      workflow_run_conclusion == 'success'
+    steps:
+      - name: download pr artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ workflow_run_workflow_id }}
+          name: pr
+      - name: save PR id
+        id: pr
+        run: echo "::set-output name=id::$(<pr-id.txt)"
+      - name: download _site artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ workflow_run_workflow_id }}
+          workflow_conclusion: success
+          name: _site
+      - run: |
+          unzip _site.zip
+
+      - name: Upload surge service and generate preview URL
+        id: deploy
+        run: |
+          export DEPLOY_DOMAIN=https://preview-pr${{ steps.pr.outputs.id }}-${{ project_name }}.surge.sh
+          npx surge --project ./_site --domain $DEPLOY_DOMAIN --token ${{ secrets.TDESIGN_SURGE_TOKEN }}
+          echo the preview URL is $DEPLOY_DOMAIN
+
+      - name: update status comment
+        uses: actions-cool/maintain-one-comment@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            PR 预览产物在 https://preview-pr${{ steps.pr.outputs.id }}-${{ project_name }}.surge.sh
+          number: ${{ steps.pr.outputs.id }}
+      
+      - run: |
+          rm -rf _site/
+
+      - name: The job failed
+        if: ${{ failure() }}
+        uses: actions-cool/maintain-one-comment@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            PR 预览生成失败。
+          number: ${{ steps.pr.outputs.id }}
+
+  preview-failed:
+    runs-on: ubuntu-latest
+    if: >
+      workflow_run_event == 'pull_request' &&
+      workflow_run_conclusion == 'failure'
+    steps:
+      - name: download pr artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ workflow_run_workflow_id }}
+          name: pr
+      - name: save PR id
+        id: pr
+        run: echo "::set-output name=id::$(<pr-id.txt)"
+      - name: The job failed
+        uses: actions-cool/maintain-one-comment@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            Deploy PR Preview failed， {{ workflow_run_conclusion }} at ${{ workflow_run_workflow_id }}.
+          number: ${{ steps.pr.outputs.id }}

--- a/.github/workflows/test-build-demo.yml
+++ b/.github/workflows/test-build-demo.yml
@@ -1,0 +1,13 @@
+# 文件名建议统一为 pull-request.yml 
+# 应用 test-build.yml 的 demo
+
+name: MAIN_PULL_REQUEST
+
+on:
+  pull_request:
+    branches: [develop, main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  call-test-build:
+    uses: Tencent/tdesign/.github/workflows/test-build.yml@main

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,87 @@
+name: TEST_AND_BUILD
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: check_email
+        run: |
+          log_emails=$(git log --pretty=format:"%ae %ce" -1) && if [[ ${log_emails} =~ '@tencent.com' ]];then echo $log_emails && echo "邮箱校验非法" && exit 2;else echo "邮箱校验通过";fi
+        shell: bash
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Cache nodemodules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-nodemodules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: npm install
+        shell: bash
+
+      - run: npm run lint
+      - run: npm run test
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Cache nodemodules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-nodemodules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: npm install
+        shell: bash
+
+      - name: Build site
+        run: npm run site:preview
+
+      - run: |
+          zip -r _site.zip _site
+
+      - name: upload _site artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: _site
+          path: _site.zip
+          retention-days: 5
+
+      - name: Save PR number
+        if: ${{ always() }}
+        run: echo ${{ github.event.number }} > ./pr-id.txt
+
+      - name: Upload PR number
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: ./pr-id.txt


### PR DESCRIPTION
添加统一的可复用的工作流
一类是重复工作流供其他仓库调用同时提供调用了 demo
- PREVIEW
- TEST_AND_BUILD

一类是自动强制 copy 到其他仓库
- 当在 issue 的 comment 回复类似 `Duplicate of #111` 这样的话，issue 将被自动打上 重复提交标签 并且 cloese
- 当被打上 Need Reproduce 标签时候，自动提示需要重现实例

