### PR TITLE
build: replace deprecating command

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,7 +21,7 @@ jobs:
           name: pr
       - name: save PR id
         id: pr
-        run: echo "::set-output name=id::$(<pr-id.txt)"
+        run: echo "id=$(<pr-id.txt)" >> $GITHUB_OUTPUT
       - name: download _site artifact
         uses: dawidd6/action-download-artifact@v2
         with:
@@ -39,7 +39,7 @@ jobs:
           export DEPLOY_DOMAIN=https://preview-pr${{ steps.pr.outputs.id }}-$project_name.surge.sh
           npx surge --project ./_site --domain $DEPLOY_DOMAIN --token ${{ secrets.TDESIGN_SURGE_TOKEN }}
           echo the preview URL is $DEPLOY_DOMAIN
-          echo "::set-output name=url::$DEPLOY_DOMAIN"
+          echo "url=$DEPLOY_DOMAIN" >> $GITHUB_OUTPUT
       - name: update status comment
         uses: actions-cool/maintain-one-comment@v2.0.0
         with:
@@ -79,7 +79,7 @@ jobs:
           name: pr
       - name: save PR id
         id: pr
-        run: echo "::set-output name=id::$(<pr-id.txt)"
+        run: echo "id=$(<pr-id.txt)" >> $GITHUB_OUTPUT
       - name: The job failed
         uses: actions-cool/maintain-one-comment@v2.0.0
         with:


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
无

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
语法变更，将在 31st May 2023 失效，因此使用最新语法设置 outputs。
相关链接：https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
