### PR TITLE
fix: `td-theme-generator` and `td-doc-changelog` rendering issues

### DIFF
--- a/packages/components/src/styles/dark.less
+++ b/packages/components/src/styles/dark.less
@@ -76,14 +76,9 @@
   --text-placeholder: rgba(255, 255, 255, .35); // 占位符文字色彩
   --text-disabled: rgba(255, 255, 255, .22); // 文字disabled态
   --text-anti: #fff; // 文字反色色彩
-  --text-interactive: #4582E6; // 主题色文字色彩
 
   // 主题色相关
   // 主题相关配置
-  --brand-main: #4582e6; // 品牌色
-  --brand-main-hover: #2667d4; // 品牌色hover
-  --brand-main-focus: #173463; // 品牌色 focus
-  --brand-main-disabled: #143975; // 品牌色disabled
   --brand-main-light: rgba(69, 130, 230, 0.2);
   --error-1: #472324;
   --error-8: #ec888e;
@@ -110,6 +105,3 @@
   --bg-color-theme-radio: #424242;
   --bg-color-theme-radio-active: #5e5e5e;
 }
-
-// @media (prefers-color-scheme: dark) {}
-//   :root:not(.light) {}

--- a/packages/components/src/styles/vars.less
+++ b/packages/components/src/styles/vars.less
@@ -100,14 +100,15 @@
   --text-placeholder: rgba(0, 0, 0, .4); // 占位符文字色彩
   --text-disabled: rgba(0, 0, 0, .26); // 文字disabled态
   --text-anti: #fff; // 文字反色色彩
-  --text-interactive: #0052d9; // 主题色文字色彩
+  --text-interactive: var(--td-brand-color); // 主题色文字色彩
 
   // 主题色相关
   // 主题相关配置
-  --brand-main: #0052d9; // 品牌色
-  --brand-main-hover: #366ef4; // 品牌色hover
-  --brand-main-focus: #d9e1ff; // 品牌色 focus
-  --brand-main-disabled: #b5c7ff; // 品牌色disabled
+  --brand-main: var(--td-brand-color);
+  // 移动端缺失 hover Token 时，使用 active 兜底
+  --brand-main-hover: var(--td-brand-color-hover, var(--td-brand-color-active)); 
+  --brand-main-focus: var(--td-brand-color-focus);
+  --brand-main-disabled: var(--td-brand-color-disabled);
   --brand-main-light: rgba(0, 82, 217, .1);
   --error-1: #fff0ed;
   --error-8: #881f1c;

--- a/packages/theme-generator/src/Generator.vue
+++ b/packages/theme-generator/src/Generator.vue
@@ -135,9 +135,13 @@ export default {
 .t-radio-button__label {
   font-size: 14px;
 }
-
 .t-slider__button {
   width: 16px;
   height: 16px;
+}
+.t-button--variant-base.t-button--theme-primary:hover,
+.t-button--variant-base.t-button--theme-primary:focus-visible {
+  border-color: var(--brand-main-hover);
+  background-color: var(--brand-main-hover);
 }
 </style>

--- a/packages/theme-generator/src/common/Themes/index.js
+++ b/packages/theme-generator/src/common/Themes/index.js
@@ -238,7 +238,7 @@ export function exportCustomTheme(device = 'web') {
     `;
   }
 
-  if (isMobile) {
+  if (isMobile(device)) {
     finalCssString = removeCssProperties(finalCssString, MOBILE_MISSING_TOKENS);
   }
 

--- a/packages/theme-generator/src/common/utils/vars.css
+++ b/packages/theme-generator/src/common/utils/vars.css
@@ -58,7 +58,7 @@
   --text-anti: #fff;
   --text-interactive: var(--td-brand-color);
   --brand-main: var(--td-brand-color);
-  --brand-main-hover: var(--td-brand-color-hover);
+  --brand-main-hover: var(--td-brand-color-hover, var(--td-brand-color-active)); 
   --brand-main-focus: var(--td-brand-color-focus);
   --brand-main-disabled: var(--td-brand-color-disabled);
   --brand-main-light: rgba(0, 82, 217, .1);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix: 在移动端引入主题生成器和日志组件时，`td-brand-color-hover` Token 缺失，使用 `td-brand-color-active` 兜底
- fix: 日志组件将 `@callback` 函数写法误判为用户名渲染为链接
- fix: 日志组件滚动条重置位置失败

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
