### PR TITLE
fix(td-doc): enhance visibility control for changelog entry on scroll

### DIFF
--- a/packages/components/src/components/td-code/index.js
+++ b/packages/components/src/components/td-code/index.js
@@ -1,10 +1,8 @@
-import { html, define } from 'hybrids';
+import { define, html } from 'hybrids';
 import style from './style.less';
 
 export default define({
   tag: 'td-code',
   text: '',
-  render: ({ text }) => html`
-    <code class="TDesign-code">${text}</code>
-  `.css`${style}`,
+  render: ({ text }) => html`<code class="TDesign-code">${text}</code>`.css`${style}`,
 });

--- a/packages/components/src/components/td-doc-header/index.js
+++ b/packages/components/src/components/td-doc-header/index.js
@@ -88,6 +88,7 @@ export default define({
         const { scrollTop } = document.documentElement;
         // 吸顶效果
         const background = shadowRoot.querySelector('.TDesign-doc-header__background') || { style: {} };
+        const changelogEntry = shadowRoot.querySelector('#TDesign-doc-changelog__entry') || { style: {} };
         const title = shadowRoot.querySelector('.TDesign-doc-header__info-title') || { style: {} };
         const describe = shadowRoot.querySelector('.TDesign-doc-header__info-describe') || { style: {} };
         const thumb = shadowRoot.querySelector('.TDesign-doc-header__thumb') || { style: {} };
@@ -108,6 +109,7 @@ export default define({
               opacity: 1,
               visibility: 'visible',
             });
+            Object.assign(changelogEntry.style, { opacity: 1, visibility: 'visible' });
             Object.assign(background.style, { position: 'fixed', top: '0', left: asideWidth });
             tabs &&
               Object.assign(tabs.style, {
@@ -120,6 +122,7 @@ export default define({
         } else if (scrollTop > 192 && scrollTop < 228) {
           if (title.style.visibility !== 'hidden') {
             Object.assign(title.style, { opacity: 0, visibility: 'hidden' });
+            Object.assign(changelogEntry.style, { opacity: 0, visibility: 'hidden' });
             Object.assign(thumb.style, { opacity: 0, visibility: 'hidden' });
             Object.assign(describe.style, { opacity: 0, visibility: 'hidden' });
 
@@ -135,6 +138,7 @@ export default define({
               opacity: 1,
               visibility: 'visible',
             });
+            Object.assign(changelogEntry.style, { opacity: 1, visibility: 'visible' });
             Object.assign(describe.style, { opacity: 1, visibility: 'visible' });
             Object.assign(background.style, { position: 'absolute', top: 'unset', left: '0' });
             tabs && Object.assign(tabs.style, { position: 'absolute', top: '228px' });

--- a/packages/components/src/styles/docs.less
+++ b/packages/components/src/styles/docs.less
@@ -229,6 +229,7 @@ div[name="DESIGN"] {
     margin: 48px 0 8px;
     display: flex;
     align-items: center;
+    white-space: pre-wrap;
 
     .title-link(24px, 24px);
   }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


1. 变更日志的入口按钮没有与页面大标题同步隐藏和出现
<img width="80%" src="https://github.com/user-attachments/assets/ba0da740-bef8-43fd-a3f0-0927ae236ba1" />


2. 行内代码后面都多出了一个空格
<img width="80%" src="https://github.com/user-attachments/assets/48141342-86f9-44d4-9da0-0cfc1f023ad1" />


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
