### PR TITLE
fix(theme): fixed an error in the exported style file content for mini

### DIFF
--- a/packages/theme-generator/src/common/themes/core.js
+++ b/packages/theme-generator/src/common/themes/core.js
@@ -96,17 +96,16 @@ export function exportCustomStyleSheet(device) {
 
   const cssString = extractRootContent(styleSheet?.textContent);
   const darkCssString = extractRootContent(darkStyleSheet?.textContent);
-  const extraCssString = extraStyleSheet?.textContent || '';
+  const extraCssString = extractRootContent(extraStyleSheet?.textContent);
 
   let finalCssString;
   if (isUniApp(device)) {
     finalCssString = `
       @media (prefers-color-scheme: light) {
-      /* #ifdef H5 */
-      :root,
-      /* #endif */
-      page,
-      .page {
+        /* #ifdef H5 */
+        :root,
+        /* #endif */
+        page, .page {
           ${cssString}
         }
       }
@@ -114,12 +113,16 @@ export function exportCustomStyleSheet(device) {
         /* #ifdef H5 */
         :root,
         /* #endif */
-        page,
-        .page {
+        page, .page {
           ${darkCssString}
         }
       }
-      ${extraCssString}
+      /* #ifdef H5 */
+      :root,
+      /* #endif */
+      page, .page {
+        ${extraCssString}
+      }
     `;
   } else if (isMiniProgram(device)) {
     finalCssString = `
@@ -133,7 +136,9 @@ export function exportCustomStyleSheet(device) {
           ${darkCssString}
         }
       }
-      ${extraCssString}
+      page, .page {
+        ${extraCssString}
+      }
     `;
   } else {
     finalCssString = `
@@ -143,7 +148,9 @@ export function exportCustomStyleSheet(device) {
       :root.dark, :root[theme-mode="dark"] {
         ${darkCssString}
       }
-      ${extraCssString}
+      :root {
+        ${extraCssString}
+      }
     `;
   }
 


### PR DESCRIPTION
### 主题生成器
- 修复小程序/uniapp 端主题样式文件中选择器名称错误
> <img width="400" height="204" alt="截屏2026-02-05 22 41 30" src="https://github.com/user-attachments/assets/297aff1f-3f8e-4a43-914d-db8b80eefceb" />
