### PR TITLE
fix(site): incorrect inline code rendering in changelog

### DIFF
--- a/packages/site-components/src/components/td-doc-changelog/index.js
+++ b/packages/site-components/src/components/td-doc-changelog/index.js
@@ -157,7 +157,10 @@ function replaceSpecialTags(html) {
       // @用户名 (且不在反引号内)
       .replace(/(?<!`)@([a-zA-Z0-9-_]+)(?!`)/g, '<a href="https://github.com/$1" target="_blank">@$1</a>')
       // 行内 code
-      .replace(/`([^`]+)`/g, (_, param) => `<td-code text="${param}"></td-code>`)
+      .replace(
+        /`([^`]+)`/g,
+        (_, param) => `<td-code text="${param.replace(/&/g, '&amp;').replace(/"/g, '&quot;')}"></td-code>`,
+      )
   );
 }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

（修复前后）

<img width="400" src="https://github.com/user-attachments/assets/1b4c0e76-aa79-4bb8-b82b-8a2b160a720a" />

<img width="300"  src="https://github.com/user-attachments/assets/1c177b14-ea32-4a91-92b8-3ca598f474c7" />

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(site-components): 修复变更日志的行内代码存在双引号时渲染异常

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
