### PR TITLE
fix(theme-generator): some styles missing from exported tcloud CSS

### DIFF
--- a/packages/theme-generator/src/common/themes/core.js
+++ b/packages/theme-generator/src/common/themes/core.js
@@ -3,7 +3,7 @@ import { Color } from 'tvision-color';
 
 import GENERATOR_VARIABLES from '!raw-loader!./built-in/css/vars.css';
 
-import { appendStyleSheet, clearLocalItem, downloadFile, extractRootContent, setUpModeObserver } from '../utils';
+import { appendStyleSheet, clearLocalItem, downloadFile, parseRootCss, setUpModeObserver } from '../utils';
 
 import {
   MOBILE_RECOMMEND_THEMES,
@@ -94,9 +94,9 @@ export function exportCustomStyleSheet(device) {
   const darkStyleSheet = document.getElementById(CUSTOM_DARK_ID);
   const extraStyleSheet = document.getElementById(CUSTOM_EXTRA_ID);
 
-  const cssString = extractRootContent(styleSheet?.textContent);
-  const darkCssString = extractRootContent(darkStyleSheet?.textContent);
-  const extraCssString = extractRootContent(extraStyleSheet?.textContent);
+  const { rootContent: cssString } = parseRootCss(styleSheet?.textContent);
+  const { rootContent: darkCssString } = parseRootCss(darkStyleSheet?.textContent);
+  const { rootContent: extraCssString, restContent: extraRestCssString } = parseRootCss(extraStyleSheet?.textContent);
 
   let finalCssString;
   if (isUniApp(device)) {
@@ -123,6 +123,7 @@ export function exportCustomStyleSheet(device) {
       page, .page {
         ${extraCssString}
       }
+      ${extraRestCssString}
     `;
   } else if (isMiniProgram(device)) {
     finalCssString = `
@@ -139,6 +140,7 @@ export function exportCustomStyleSheet(device) {
       page, .page {
         ${extraCssString}
       }
+      ${extraRestCssString}
     `;
   } else {
     finalCssString = `
@@ -151,6 +153,7 @@ export function exportCustomStyleSheet(device) {
       :root {
         ${extraCssString}
       }
+      ${extraRestCssString}
     `;
   }
 

--- a/packages/theme-generator/src/common/themes/iframe.js
+++ b/packages/theme-generator/src/common/themes/iframe.js
@@ -1,4 +1,4 @@
-import { extractRootContent, getThemeMode, setUpModeObserver } from '../utils';
+import { getThemeMode, parseRootCss, setUpModeObserver } from '../utils';
 import { CUSTOM_DARK_ID, CUSTOM_THEME_ID, isMiniProgram, isMobile, isUniApp } from './core';
 
 /* ----- 同步亮暗模式 -----  */
@@ -23,7 +23,7 @@ function handleMiniProgramModeChange(iframe, mode, uniapp = false) {
     const style = document.createElement('style');
     style.id = currentModeId;
 
-    const cssString = extractRootContent(themeStyle.innerText);
+    const { rootContent: cssString } = parseRootCss(themeStyle.innerText);
     const selector = uniapp ? 'uni-page-body' : 'body';
     style.textContent = `${selector} {\n${cssString}\n}`;
 
@@ -56,7 +56,8 @@ function handleMobileTokenChange(iframe, styleElement) {
 
 function handleMiniProgramTokenChange(iframe, styleElement, uniapp = false) {
   const selector = uniapp ? 'uni-page-body' : 'body';
-  const updatedCss = `${selector} {\n${extractRootContent(styleElement.innerText)}\n}`;
+  const { rootContent } = parseRootCss(styleElement.innerText);
+  const updatedCss = `${selector} {\n${rootContent}\n}`;
 
   const updatedId = styleElement.id;
   const iframeStyleElement = iframe.contentDocument.getElementById(updatedId);

--- a/packages/theme-generator/src/common/themes/store.js
+++ b/packages/theme-generator/src/common/themes/store.js
@@ -11,6 +11,10 @@ export const themeStore = Vue.observable({
   updateDevice(device) {
     this.device = device;
     this.theme = getInitialTheme(device);
+    // 若用户未自定义过主题色，brandColor 跟随当前主题
+    if (!getOptionFromLocal('color')) {
+      this.brandColor = this.theme.value;
+    }
   },
   updateTheme(theme) {
     this.theme = theme;

--- a/packages/theme-generator/src/common/utils/index.js
+++ b/packages/theme-generator/src/common/utils/index.js
@@ -83,12 +83,21 @@ export function downloadFile(blob, fileName) {
 }
 
 /**
- * 从 CSS 文本中提取 `:root` 中的内容
+ * 解析 CSS 文本，拆分出 `:root` 中的变量内容与其余的选择器规则
  */
-export function extractRootContent(cssText) {
-  // 匹配 {} 内的内容
-  const match = cssText.match(/{([^}]*)}/);
-  return match ? match[1].trim() : '';
+export function parseRootCss(cssText) {
+  if (!cssText) return { rootContent: '', restContent: '' };
+
+  const rootBlockMatch = cssText.match(/:root\s*\{([^}]*)\}/);
+
+  if (!rootBlockMatch) {
+    return { rootContent: '', restContent: cssText.trim() };
+  }
+
+  const rootContent = rootBlockMatch[1].trim();
+  const restContent = cssText.replace(rootBlockMatch[0], '').trim();
+
+  return { rootContent, restContent };
 }
 
 /**


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

【1】`:root` 后面这部分导出时缺失
<img width="300" src="https://github.com/user-attachments/assets/cd762e07-b276-456a-bd9e-faf2aa5ac047" />


【2】刷新前后

<img width="400" src="https://github.com/user-attachments/assets/60ab6399-9d72-4acc-b776-cdbeb2545175" />
<img width="400" src="https://github.com/user-attachments/assets/bd65a6bb-601e-4408-8fc2-e08566fd61c3" />

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(theme-generator): 修复自定义主题部分覆盖样式未正确导出的问题
- fix(theme-generator): 修复刷新页面后，自定义主题的主色调被默认主题覆盖的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
