### PR TITLE
fix(theme-generator): 修复阴影面板选择预设时下载导出为 null 的问题

### DIFF
--- a/packages/theme-generator/src/Generator.vue
+++ b/packages/theme-generator/src/Generator.vue
@@ -80,6 +80,9 @@ export default {
 .t-popconfirm .t-icon {
   font-size: 20px !important;
 }
+.t-popup__content {
+  box-shadow: var(--shadow-2);
+}
 .t-popup .t-select-option {
   font-size: 14px;
 }

--- a/packages/theme-generator/src/shadow-panel/index.vue
+++ b/packages/theme-generator/src/shadow-panel/index.vue
@@ -127,7 +127,7 @@ export default {
         const { name } = ShadowTypeMap[index];
 
         const isCustom = this.step === ShadowSelectType.Self_Defined;
-        modifyToken(name, isCustom ? newShadow : null);
+        modifyToken(name, newShadow, isCustom);
       }
     },
   },


### PR DESCRIPTION
选择非自定义阴影预设（如超轻）时，modifyToken 传入 null 作为新值，
导致样式表中阴影变量被替换为 null。改为始终传入实际阴影值，
仅在自定义模式时不保存到 localStorage。


<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
<img width="1910" height="1174" alt="image" src="https://github.com/user-attachments/assets/35a5f416-c860-45a5-b0fb-c8d49c7a408c" />

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
