### PR TITLE
fix(site-components): sync doc demo theme changes

### DIFF
--- a/packages/site-components/src/components/td-doc-demo/index.js
+++ b/packages/site-components/src/components/td-doc-demo/index.js
@@ -27,9 +27,9 @@ export default define({
         invalidate();
       }
 
-      window.addEventListener('localStorage', themeChange);
+      window.addEventListener('storageChange', themeChange);
 
-      return () => window.removeEventListener('localStorage', themeChange);
+      return () => window.removeEventListener('storageChange', themeChange);
     },
   },
   activeStyleMap: {

--- a/packages/site-components/test/td-doc-demo.test.js
+++ b/packages/site-components/test/td-doc-demo.test.js
@@ -1,0 +1,62 @@
+/* eslint-env jest */
+
+const mockDefine = jest.fn((definition) => definition);
+const mockHtml = jest.fn();
+const mockDispatch = jest.fn();
+
+jest.mock('hybrids', () => ({
+  define: mockDefine,
+  html: mockHtml,
+  dispatch: mockDispatch,
+}));
+
+jest.mock('../src/components/td-doc-demo/style.less?inline', () => '', { virtual: true });
+jest.mock('@images/code.svg?raw', () => '', { virtual: true });
+jest.mock('prismjs', () => ({ highlight: jest.fn(), languages: {} }));
+jest.mock('prismjs/components/prism-markup.js', () => ({}));
+jest.mock('prismjs/components/prism-css.js', () => ({}));
+jest.mock('prismjs/components/prism-jsx.js', () => ({}));
+jest.mock('prismjs/components/prism-javascript.js', () => ({}));
+jest.mock('prismjs/components/prism-typescript', () => ({}));
+
+const docDemo = require('../src/components/td-doc-demo').default;
+
+describe('td-doc-demo theme synchronization', () => {
+  let listeners;
+
+  beforeEach(() => {
+    listeners = new Map();
+    global.window = {
+      addEventListener: jest.fn((type, listener) => listeners.set(type, listener)),
+      removeEventListener: jest.fn((type, listener) => {
+        if (listeners.get(type) === listener) listeners.delete(type);
+      }),
+    };
+    global.localStorage = {
+      getItem: jest.fn(() => 'dark'),
+    };
+  });
+
+  afterEach(() => {
+    delete global.window;
+    delete global.localStorage;
+  });
+
+  it('updates the code block theme when td-theme-tabs changes the site theme', () => {
+    const host = {};
+    const invalidate = jest.fn();
+    const cleanup = docDemo.theme.connect(host, 'theme', invalidate);
+    const listener = listeners.get('storageChange');
+
+    expect(listener).toEqual(expect.any(Function));
+
+    listener();
+
+    expect(host.theme).toBe('dark');
+    expect(invalidate).toHaveBeenCalledTimes(1);
+
+    cleanup();
+
+    expect(window.removeEventListener).toHaveBeenCalledWith('storageChange', listener);
+  });
+});


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无关联 Issue。本问题在源码审计中发现；以 `storageChange` 和 `td-doc-demo` 检索开放及已关闭 PR，未发现重复实现。

### 💡 需求背景和解决方案

`td-theme-tabs` 保存主题后派发 `storageChange`，而 `td-doc-demo` 订阅了没有任何生产者派发的 `localStorage` 事件。主题切换后，文档示例代码区会继续保留旧的亮暗主题 class。

将订阅和清理统一为 `storageChange`，并补充回归测试，验证示例会读取新主题、触发重新渲染并正确解除监听。

### 📝 更新日志

- fix(site-components): 文档示例代码区会随站点主题切换同步亮暗样式

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 🧪 验证

- `corepack pnpm --filter @tdesign/site-components test`
- `corepack pnpm exec eslint packages/site-components/src/components/td-doc-demo/index.js packages/site-components/test/td-doc-demo.test.js`
- `corepack pnpm exec prettier --check packages/site-components/src/components/td-doc-demo/index.js packages/site-components/test/td-doc-demo.test.js`
- `corepack pnpm --filter @tdesign/site-components build`
