### PR TITLE
fix(site-components): clean up doc header listeners

### DIFF
--- a/packages/site-components/src/components/td-doc-header/index.js
+++ b/packages/site-components/src/components/td-doc-header/index.js
@@ -176,35 +176,29 @@ export default define({
         }
       }
 
-      changeTitlePos();
-
-      mediaQuery.addEventListener('change', () => {
+      function handleMediaChange() {
         changeTitlePos();
         checkDescribeLineOverflow(host);
-      });
-      window.addEventListener('resize', () => {
+      }
+
+      function handleResize() {
         changeTitlePos();
         const currentWidth = window.innerWidth;
         if (currentWidth !== lastWidth) {
           lastWidth = currentWidth;
           checkDescribeLineOverflow(host);
         }
-      });
+      }
+
+      changeTitlePos();
+
+      mediaQuery.addEventListener('change', handleMediaChange);
+      window.addEventListener('resize', handleResize);
       document.addEventListener('scroll', changeTitlePos);
 
       return () => {
-        mediaQuery.removeEventListener('change', () => {
-          changeTitlePos();
-          checkDescribeLineOverflow(host);
-        });
-        window.removeEventListener('resize', () => {
-          changeTitlePos();
-          const currentWidth = window.innerWidth;
-          if (currentWidth !== lastWidth) {
-            lastWidth = currentWidth;
-            checkDescribeLineOverflow(host);
-          }
-        });
+        mediaQuery.removeEventListener('change', handleMediaChange);
+        window.removeEventListener('resize', handleResize);
         document.removeEventListener('scroll', changeTitlePos);
       };
     },

--- a/packages/site-components/test/td-doc-header.test.js
+++ b/packages/site-components/test/td-doc-header.test.js
@@ -1,0 +1,67 @@
+/* eslint-env jest */
+
+const mockDefine = jest.fn((definition) => definition);
+const mockHtml = jest.fn();
+
+jest.mock('hybrids', () => ({
+  define: mockDefine,
+  html: mockHtml,
+}));
+
+jest.mock('@config/locale.js', () => ({ getLocale: jest.fn(() => ({})) }), { virtual: true });
+jest.mock('@config/spline', () => ({}), { virtual: true });
+jest.mock('@images/history.svg?raw', () => '', { virtual: true });
+jest.mock(
+  '@utils',
+  () => ({
+    isComponentPage: jest.fn(),
+    isGlobalConfigPage: jest.fn(),
+    mobileBodyStyle: {},
+    parseBoolean: jest.fn(),
+    watchHtmlMode: jest.fn(),
+  }),
+  { virtual: true },
+);
+jest.mock('../src/components/td-doc-header/style.less?inline', () => '', { virtual: true });
+
+const docHeader = require('../src/components/td-doc-header').default;
+
+describe('td-doc-header fixed title lifecycle', () => {
+  let mediaQuery;
+
+  beforeEach(() => {
+    mediaQuery = {
+      matches: false,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    global.window = {
+      innerWidth: 1440,
+      matchMedia: jest.fn(() => mediaQuery),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    global.document = {
+      documentElement: { scrollTop: 0 },
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      querySelector: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    delete global.window;
+    delete global.document;
+  });
+
+  it('removes the same media and resize listeners that it registers', () => {
+    const cleanup = docHeader.fixedTitle.connect({ shadowRoot: null });
+    const mediaListener = mediaQuery.addEventListener.mock.calls[0][1];
+    const resizeListener = window.addEventListener.mock.calls[0][1];
+
+    cleanup();
+
+    expect(mediaQuery.removeEventListener).toHaveBeenCalledWith('change', mediaListener);
+    expect(window.removeEventListener).toHaveBeenCalledWith('resize', resizeListener);
+  });
+});


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无关联 Issue。本问题在源码审计中发现；以 `td-doc-header`、`removeEventListener` 和 `fixedTitle` 检索开放及已关闭 PR，未发现重复实现。

### 💡 需求背景和解决方案

`td-doc-header` 为固定标题注册了 `matchMedia` 与 `resize` 监听器，但 cleanup 中创建了新的匿名函数。浏览器只能移除同一函数引用，因此组件卸载后原监听器仍会保留。

将两个回调命名为稳定闭包函数，并在注册与 cleanup 时复用它们。新增回归测试以验证移除操作使用注册时的确切回调。

### 📝 更新日志

- fix(site-components): 文档页头卸载时会正确清理媒体查询和窗口尺寸监听器

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 🧪 验证

- `corepack pnpm --filter @tdesign/site-components test`
- `corepack pnpm exec eslint packages/site-components/src/components/td-doc-header/index.js packages/site-components/test/td-doc-header.test.js`
- `corepack pnpm exec prettier --check packages/site-components/src/components/td-doc-header/index.js packages/site-components/test/td-doc-header.test.js`
- `corepack pnpm --filter @tdesign/site-components build`
