### PR TITLE
fix(site-components): preserve latest doc search results

### DIFF
--- a/packages/site-components/src/components/td-doc-search/state.js
+++ b/packages/site-components/src/components/td-doc-search/state.js
@@ -225,13 +225,14 @@ export async function runSearch(host, query) {
   }
 
   if (host._abort) host._abort.abort();
-  host._abort = new AbortController();
+  const requestController = new AbortController();
+  host._abort = requestController;
   host._loading = true;
 
   try {
     const hits = await searchAlgolia({
       query: q,
-      signal: host._abort.signal,
+      signal: requestController.signal,
       appId: host.appId,
       apiKey: host.apiKey,
       indexName: host.indexName,
@@ -239,11 +240,11 @@ export async function runSearch(host, query) {
       hitsPerPage: host.hitsPerPage,
     });
     // 请求返回前可能已被新的查询打断，此时不应再落盘
-    if (host._abort.signal.aborted) return;
+    if (requestController.signal.aborted || host._abort !== requestController) return;
     host._loading = false;
     applyGroups(host, groupHits(hits));
   } catch (err) {
-    if (err?.name === 'AbortError') return;
+    if (err?.name === 'AbortError' || requestController.signal.aborted || host._abort !== requestController) return;
     host._loading = false;
     applyGroups(host, []);
   }

--- a/packages/site-components/test/td-doc-search-state.test.js
+++ b/packages/site-components/test/td-doc-search-state.test.js
@@ -1,0 +1,62 @@
+/* eslint-env jest */
+
+const mockSearchAlgolia = jest.fn();
+
+jest.mock('../src/components/td-doc-search/algolia.js', () => ({
+  searchAlgolia: mockSearchAlgolia,
+  groupHits: jest.fn((hits) => [{ key: 'results', title: 'Results', items: hits }]),
+  formatHit: jest.fn(),
+}));
+
+jest.mock('../src/components/td-doc-search/recent.js', () => ({
+  listRecent: jest.fn(() => []),
+}));
+
+jest.mock('../src/components/td-doc-search/constants.js', () => ({
+  DEBOUNCE_MS: 200,
+  VIEW: {},
+}));
+
+const { runSearch } = require('../src/components/td-doc-search/state.js');
+
+describe('td-doc-search request lifecycle', () => {
+  beforeEach(() => {
+    mockSearchAlgolia.mockReset();
+  });
+
+  it('keeps newer results when an older request fails after it completes', async () => {
+    const pending = [];
+    mockSearchAlgolia.mockImplementation(
+      ({ query }) => new Promise((resolve, reject) => pending.push({ query, resolve, reject })),
+    );
+
+    const host = {
+      _groups: [],
+      _activeKey: null,
+      _flatHits: [],
+      _currentIndex: 0,
+      _loading: false,
+      _abort: null,
+    };
+    const newerHit = {
+      __formatted: {
+        url: '/vue-next/components/button',
+        title: 'Button',
+        subtitle: '',
+        breadcrumb: '',
+      },
+    };
+
+    const olderSearch = runSearch(host, 'old query');
+    const newerSearch = runSearch(host, 'new query');
+
+    pending.find((request) => request.query === 'new query').resolve([newerHit]);
+    await newerSearch;
+
+    pending.find((request) => request.query === 'old query').reject(new Error('late network failure'));
+    await olderSearch;
+
+    expect(host._flatHits).toEqual([newerHit.__formatted]);
+    expect(host._loading).toBe(false);
+  });
+});


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

No related issue. Duplicate search keywords: `doc-search race`, `td-doc-search`.

### 💡 需求背景和解决方案

An older documentation search can settle after a newer search has completed and clear the current results. The request controller is now captured for each search and results are applied only while that controller is still current.

Added a regression test covering a late failure from an older request after newer results are displayed.

Validation:

- `pnpm --filter @tdesign/site-components exec jest --coverage --runInBand`
- `pnpm exec eslint packages/site-components/src/components/td-doc-search/state.js packages/site-components/test/td-doc-search-state.test.js`
- `pnpm exec prettier --check packages/site-components/src/components/td-doc-search/state.js packages/site-components/test/td-doc-search-state.test.js`
- `pnpm --filter @tdesign/site-components build`

### 📝 更新日志

- fix(site-components): preserve the latest documentation search results.

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
