### PR TITLE
fix(site-components): clean up doc popup lifecycle

### DIFF
--- a/packages/site-components/src/components/td-doc-popup/index.js
+++ b/packages/site-components/src/components/td-doc-popup/index.js
@@ -38,8 +38,13 @@ export default define({
     connect: (host) => {
       const { reference, placement } = host;
       let resizeObserver;
+      let portalFrameId;
+      let popperFrameId;
+      let isConnected = true;
 
-      requestAnimationFrame(() => {
+      portalFrameId = requestAnimationFrame(() => {
+        if (!isConnected) return;
+
         host.portals = document.getElementById('__td_portals__');
         if (!host.portals) {
           host.portals = document.createElement('div');
@@ -62,7 +67,9 @@ export default define({
         host.portal.addEventListener('mouseleave', () => handleMouseEvent(host, 'leave'));
         host.portals.appendChild(host.portal);
 
-        requestAnimationFrame(() => {
+        popperFrameId = requestAnimationFrame(() => {
+          if (!isConnected) return;
+
           const isVertical = ['top', 'bottom'].some((p) => placement.includes(p));
           host.popper = createPopper(reference, host.portal, {
             placement,
@@ -103,7 +110,11 @@ export default define({
       document.addEventListener('click', clickOutside);
 
       return () => {
-        host.portals?.removeChild?.(host.portal);
+        isConnected = false;
+        if (portalFrameId != null) cancelAnimationFrame(portalFrameId);
+        if (popperFrameId != null) cancelAnimationFrame(popperFrameId);
+        host.popper?.destroy?.();
+        host.portal?.remove?.();
         document.removeEventListener('click', clickOutside);
         resizeObserver?.disconnect?.();
       };

--- a/packages/site-components/test/td-doc-popup.test.js
+++ b/packages/site-components/test/td-doc-popup.test.js
@@ -1,0 +1,100 @@
+/* eslint-env jest */
+
+const mockDefine = jest.fn((definition) => definition);
+const mockHtml = jest.fn();
+const mockDispatch = jest.fn();
+const mockCreatePopper = jest.fn();
+
+jest.mock('hybrids', () => ({
+  define: mockDefine,
+  html: mockHtml,
+  dispatch: mockDispatch,
+}));
+
+jest.mock('@popperjs/core', () => ({ createPopper: mockCreatePopper }));
+jest.mock('@utils', () => ({ parseBoolean: jest.fn((value) => Boolean(value)) }), { virtual: true });
+jest.mock('../src/components/td-doc-popup/style.less?inline', () => '', { virtual: true });
+
+const docPopup = require('../src/components/td-doc-popup').default;
+
+describe('td-doc-popup lifecycle', () => {
+  let frames;
+  let portalContainer;
+
+  beforeEach(() => {
+    frames = new Map();
+    let frameId = 0;
+    portalContainer = {
+      appendChild: jest.fn(),
+      removeChild: jest.fn(),
+    };
+
+    global.requestAnimationFrame = jest.fn((callback) => {
+      const id = ++frameId;
+      frames.set(id, callback);
+      return id;
+    });
+    global.cancelAnimationFrame = jest.fn((id) => frames.delete(id));
+    global.window = {
+      ResizeObserver: jest.fn(() => ({ observe: jest.fn(), disconnect: jest.fn() })),
+    };
+    global.document = {
+      getElementById: jest.fn(() => portalContainer),
+      createElement: jest.fn(() => ({ appendChild: jest.fn(), addEventListener: jest.fn() })),
+      body: { appendChild: jest.fn() },
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    mockCreatePopper.mockReset();
+  });
+
+  afterEach(() => {
+    delete global.requestAnimationFrame;
+    delete global.cancelAnimationFrame;
+    delete global.window;
+    delete global.document;
+  });
+
+  function createHost() {
+    return {
+      reference: { offsetWidth: 240 },
+      placement: 'bottom-start',
+      portalClass: '',
+      portalStyle: '',
+      querySelector: jest.fn(() => ({})),
+    };
+  }
+
+  function flushNextFrame() {
+    const [id, callback] = frames.entries().next().value;
+    frames.delete(id);
+    callback();
+  }
+
+  it('cancels deferred portal setup when disconnected before the first frame', () => {
+    const cleanup = docPopup.visible.connect(createHost());
+
+    document.getElementById.mockReturnValue(null);
+    cleanup();
+    Array.from(frames.values()).forEach((callback) => callback());
+
+    expect(document.body.appendChild).not.toHaveBeenCalled();
+  });
+
+  it('destroys the Popper instance during cleanup', () => {
+    const popper = {
+      state: { styles: { popper: {} } },
+      update: jest.fn(),
+      destroy: jest.fn(),
+    };
+    mockCreatePopper.mockReturnValue(popper);
+
+    const cleanup = docPopup.visible.connect(createHost());
+    flushNextFrame();
+    flushNextFrame();
+
+    cleanup();
+
+    expect(popper.destroy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

No related issue. Duplicate search keywords: `td-doc-popup`, `portal cleanup`.

### 💡 需求背景和解决方案

Disconnecting a popup before its scheduled setup frame can still create a detached portal, and an initialized Popper instance was not destroyed during cleanup. The lifecycle now cancels pending frames, guards delayed callbacks, destroys Popper, and removes the portal node.

Added regression coverage for disconnection before setup and Popper cleanup after initialization.

Validation:

- `pnpm --filter @tdesign/site-components exec jest --coverage --runInBand`
- `pnpm exec eslint packages/site-components/src/components/td-doc-popup/index.js packages/site-components/test/td-doc-popup.test.js`
- `pnpm exec prettier --check packages/site-components/src/components/td-doc-popup/index.js packages/site-components/test/td-doc-popup.test.js`
- `pnpm --filter @tdesign/site-components build`

### 📝 更新日志

- fix(site-components): clean up documentation popup lifecycle resources.

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须提供
- [x] Changelog 已提供或无须提供
