### PR TITLE
fix(site-components): offset existing doc hash targets

### DIFF
--- a/packages/site-components/src/components/td-doc-content/index.js
+++ b/packages/site-components/src/components/td-doc-content/index.js
@@ -50,6 +50,8 @@ export default define({
     get: (_host, lastValue) => lastValue || undefined,
     set: (_host, value) => value,
     connect: () => {
+      let demoLoadObserver;
+
       function changeTocHeight() {
         const { scrollTop } = document.documentElement;
         // 固定右侧目录
@@ -88,17 +90,12 @@ export default define({
       }
 
       function waitForDemoLoad() {
-        const observer = new MutationObserver(() => {
-          for (const selector of CONTENT_SELECTORS) {
-            const targetElement = document.querySelector(selector);
-            if (targetElement) {
-              observer.disconnect();
-              handleAnchorScroll();
-              break;
-            }
-          }
+        if (handleDemoLoad()) return;
+
+        demoLoadObserver = new MutationObserver(() => {
+          if (handleDemoLoad()) demoLoadObserver.disconnect();
         });
-        observer.observe(document.body, { childList: true, subtree: true });
+        demoLoadObserver.observe(document.body, { childList: true, subtree: true });
       }
 
       // 加载后跳转到锚点定位处
@@ -115,14 +112,26 @@ export default define({
         window.scrollTo({ top: offsetTop - 120, left: 0 });
       }
 
+      function handleDemoLoad() {
+        const hasDemoContent = CONTENT_SELECTORS.some((selector) => document.querySelector(selector));
+        if (!hasDemoContent) return false;
+        handleAnchorScroll();
+        return true;
+      }
+
       document.addEventListener('scroll', changeTocHeight);
       document.addEventListener('click', proxyTitleAnchor);
-      window.addEventListener('load', waitForDemoLoad);
+      if (document.readyState === 'complete') {
+        waitForDemoLoad();
+      } else {
+        window.addEventListener('load', waitForDemoLoad);
+      }
 
       return () => {
         document.removeEventListener('scroll', changeTocHeight);
         document.removeEventListener('click', proxyTitleAnchor);
         window.removeEventListener('load', waitForDemoLoad);
+        demoLoadObserver?.disconnect();
       };
     },
   },

--- a/packages/site-components/test/td-doc-content.test.js
+++ b/packages/site-components/test/td-doc-content.test.js
@@ -1,0 +1,67 @@
+/* eslint-env jest */
+
+const mockDefine = jest.fn((definition) => definition);
+const mockHtml = jest.fn();
+
+jest.mock('hybrids', () => ({
+  define: mockDefine,
+  html: mockHtml,
+}));
+
+jest.mock('@utils', () => ({ mobileBodyStyle: {} }), { virtual: true });
+jest.mock('../src/components/td-doc-content/style.less?inline', () => '', { virtual: true });
+
+const docContent = require('../src/components/td-doc-content').default;
+
+describe('td-doc-content anchor scroll', () => {
+  let loadHandler;
+
+  beforeEach(() => {
+    loadHandler = null;
+    global.location = { href: 'https://tdesign.tencent.com/vue-next/components/button#api' };
+    global.window = {
+      addEventListener: jest.fn((type, listener) => {
+        if (type === 'load') loadHandler = listener;
+      }),
+      removeEventListener: jest.fn(),
+      scrollY: 0,
+      scrollTo: jest.fn(),
+    };
+    global.document = {
+      readyState: 'loading',
+      documentElement: { scrollTop: 0 },
+      querySelector: jest.fn((selector) => (selector === 'div[name="DEMO"]' ? {} : null)),
+      querySelectorAll: jest.fn(() => []),
+      getElementById: jest.fn(() => ({ getBoundingClientRect: () => ({ top: 240 }) })),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      body: {},
+    };
+    global.MutationObserver = jest.fn(() => ({ observe: jest.fn(), disconnect: jest.fn() }));
+  });
+
+  afterEach(() => {
+    delete global.location;
+    delete global.window;
+    delete global.document;
+    delete global.MutationObserver;
+  });
+
+  it('offsets a hash target that already exists when the page loads', () => {
+    const cleanup = docContent.fixedAnchor.connect();
+
+    loadHandler();
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 120, left: 0 });
+    cleanup();
+  });
+
+  it('offsets a hash target when connected after the load event', () => {
+    document.readyState = 'complete';
+
+    const cleanup = docContent.fixedAnchor.connect();
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 120, left: 0 });
+    cleanup();
+  });
+});


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

No related issue. Duplicate search keywords: `anchor scroll`, `fixed header anchor`.

### 💡 需求背景和解决方案

Direct hash links were only handled after a future DOM mutation. When the target already existed at page load, or when the component connected after the load event, the fixed header could cover the target. The component now checks existing content before observing mutations, handles completed documents immediately, and disconnects the observer on cleanup.

Added regression coverage for both load-time and post-load connection paths.

Validation:

- `pnpm --filter @tdesign/site-components exec jest --coverage --runInBand`
- `pnpm exec eslint packages/site-components/src/components/td-doc-content/index.js packages/site-components/test/td-doc-content.test.js`
- `pnpm exec prettier --check packages/site-components/src/components/td-doc-content/index.js packages/site-components/test/td-doc-content.test.js`
- `pnpm --filter @tdesign/site-components build`

### 📝 更新日志

- fix(site-components): offset existing documentation hash targets.

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须提供
- [x] Changelog 已提供或无须提供
