### PR TITLE
fix(site-components): handle raw percent code blocks

### DIFF
--- a/packages/site-components/src/components/td-code-block/index.js
+++ b/packages/site-components/src/components/td-code-block/index.js
@@ -14,6 +14,14 @@ function getLineStyle(host) {
   return `width: ${offsetWidth}px; left: ${offsetLeft}px`;
 }
 
+function decodeSlotContent(content) {
+  try {
+    return decodeURIComponent(content);
+  } catch {
+    return content;
+  }
+}
+
 function extractSlots(host) {
   const slotsEl = Array.from(host.querySelectorAll('td-code-block > [slot]'));
   const slotsName = [];
@@ -24,7 +32,7 @@ function extractSlots(host) {
     slotsContentMap[s.slot] = {
       name: s.slot,
       lang: s.lang,
-      content: decodeURIComponent(s.innerHTML),
+      content: decodeSlotContent(s.innerHTML),
     };
   });
 

--- a/packages/site-components/test/td-code-block.test.js
+++ b/packages/site-components/test/td-code-block.test.js
@@ -1,0 +1,45 @@
+/* eslint-env jest */
+
+const mockDefine = jest.fn((definition) => definition);
+const mockHtml = jest.fn(() => ({ css: jest.fn() }));
+mockHtml.set = jest.fn();
+const mockHighlight = jest.fn(() => 'highlighted');
+
+jest.mock('hybrids', () => ({
+  define: mockDefine,
+  html: mockHtml,
+}));
+
+jest.mock('prismjs', () => ({
+  highlight: mockHighlight,
+  languages: { css: {} },
+}));
+jest.mock('../src/components/td-code-block/style.less?inline', () => '', { virtual: true });
+
+const codeBlock = require('../src/components/td-code-block').default;
+
+describe('td-code-block slot decoding', () => {
+  beforeEach(() => {
+    mockHighlight.mockClear();
+  });
+
+  function renderCode(content) {
+    return codeBlock.render({
+      panel: 'css',
+      querySelectorAll: jest.fn(() => [{ slot: 'css', lang: 'css', innerHTML: content }]),
+    });
+  }
+
+  it('renders raw percent signs without throwing a URIError', () => {
+    const source = '.progress { width: 100%; }';
+
+    expect(() => renderCode(source)).not.toThrow();
+    expect(mockHighlight).toHaveBeenCalledWith(source, {}, 'css');
+  });
+
+  it('preserves support for URL-encoded slot content', () => {
+    renderCode('.progress%20%7B%20width%3A%20100%25%3B%20%7D');
+
+    expect(mockHighlight).toHaveBeenCalledWith('.progress { width: 100%; }', {}, 'css');
+  });
+});


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

No related issue. Duplicate search keywords: `td-code-block`, `URI malformed`.

### 💡 需求背景和解决方案

`decodeURIComponent` throws for ordinary raw code containing a percent sign, such as `width: 100%;`. Slot content now falls back to its raw value when it is not valid URL-encoded text, while preserving existing decoding for valid encoded content.

Added regression coverage for raw percent signs and URL-encoded slot content.

Validation:

- `pnpm --filter @tdesign/site-components exec jest --coverage --runInBand`
- `pnpm exec eslint packages/site-components/src/components/td-code-block/index.js packages/site-components/test/td-code-block.test.js`
- `pnpm exec prettier --check packages/site-components/src/components/td-code-block/index.js packages/site-components/test/td-code-block.test.js`
- `pnpm --filter @tdesign/site-components build`

### 📝 更新日志

- fix(site-components): handle raw percent signs in code block slots.

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须提供
- [x] Changelog 已提供或无须提供
