### PR TITLE
fix(theme-generator): keep brand color mode-aware

### DIFF
--- a/packages/theme-generator/src/color-panel/index.vue
+++ b/packages/theme-generator/src/color-panel/index.vue
@@ -156,7 +156,7 @@
                 :style="{
                   width: '100%',
                   'border-radius': '6px',
-                  'background-color': 'var(--brand-main)',
+                  'background-color': brandDisplayedColor,
                 }"
               >
                 <p>hsv: {{ convertFromHex(brandDisplayedColor, 'hsv') }}</p>

--- a/packages/theme-generator/src/common/themes/store.js
+++ b/packages/theme-generator/src/common/themes/store.js
@@ -29,7 +29,8 @@ export const themeStore = Vue.observable({
   },
   updateBrandColor(color) {
     this.brandColor = color;
-    document.documentElement.style.setProperty('--brand-main', color);
+    // Site components consume this alias, so keep it linked to the mode-aware brand token.
+    document.documentElement.style.setProperty('--brand-main', 'var(--td-brand-color)');
   },
   incrementRefreshId() {
     this.refreshId++;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

Fixes #884

### 💡 需求背景和解决方案

在暗色模式下选择「腾云黑 / TCloud Black」后，主题生成器会把亮色主题的原始品牌色 `#262626` 以内联样式写入 `--brand-main`。该内联值覆盖了原本指向 `--td-brand-color` 的亮暗模式语义别名，导致文档导航、代码 Tab 等使用 `--brand-main` 的文字与深色背景融在一起。

本 PR：

- 让 `--brand-main` 始终保持为 `var(--td-brand-color)`，随当前亮暗模式使用对应品牌色；
- 颜色面板的原始色预览改为直接使用 `brandDisplayedColor`，因此预览仍准确显示用户选择的 `#262626`。

复现截图（修复前）：

<img width="969" height="513" alt="TCloud Black in dark mode before the fix" src="https://github.com/user-attachments/assets/3a4eb35d-4a58-4791-b128-08e8feeb0df3" />

修复后通过主题生成器正常交互选择腾讯云主题和腾云黑预设，结果如下：

| 检查项 | 修复后结果 |
| --- | --- |
| `--brand-main` 声明 | `var(--td-brand-color)` |
| 暗色模式 `--td-brand-color` | `#939393` |
| 使用 `--brand-main` 的文字计算色 | `rgb(147, 147, 147)` |
| 颜色面板原始色预览 | `rgb(38, 38, 38)` |
| 浏览器控制台 | 0 error |

### 📝 更新日志

- fix(theme-generator): 修复腾云黑主题在暗色模式下品牌色对比度过低的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
